### PR TITLE
as_cubble method for stars and make_spatial_sf suggestions

### DIFF
--- a/R/as-cubble.R
+++ b/R/as-cubble.R
@@ -176,7 +176,10 @@ as_cubble.stars <- function(data, key, index, coords, ...){
   # time is the third
   if (is.na(stars::st_raster_type(data))) { # vector data cube
 	stopifnot(is.null(data$id),
-	          inherits(stars::st_get_dimension_values(data, 1), "sfc"))
+	          # Check if any of the dimensions is an sfc
+	          any(sapply(
+	            stars::st_dimensions(data),
+	            function(i) inherits(i$values, "sfc"))))
     data$id <- seq_len(dim(data)[1]) # recycles
     data <-  sf::st_as_sf(data, long = TRUE)
     key <-  enquo(key)

--- a/R/as-cubble.R
+++ b/R/as-cubble.R
@@ -38,7 +38,7 @@
 #'# stars - take a few seconds to run
 #' tif <- system.file("tif/L7_ETMs.tif", package = "stars")
 #' x <-  stars::read_stars(tif)
-#' x |> as_cubble()
+#' x |> as_cubble(index = band)
 #'}
 #'
 #' # don't have to supply coords if create from a sftime
@@ -172,8 +172,6 @@ as_cubble.ncdf4 <- function(data, key, index, coords, vars,
 #' @export
 as_cubble.stars <- function(data, key, index, coords, ...){
 
-  # making the assumption that long/lat are the first two dimensions
-  # time is the third
   if (is.na(stars::st_raster_type(data))) { # vector data cube
 	stopifnot(is.null(data$id),
 	          # Check if any of the dimensions is an sfc
@@ -186,13 +184,13 @@ as_cubble.stars <- function(data, key, index, coords, ...){
     index <-  enquo(index)
 	as_cubble(data, key=!!key, index=!!index)
   } else { # raster data cube
+    # making the assumption that long/lat are the first two dimensions
     longlat <- names(stars::st_dimensions(data))[1:2]
-    time <- names(stars::st_dimensions(data))[3]
-
+    index <-  enquo(index)
     as_tibble(data) |>
       mutate(id = as.integer(interaction(!!sym(longlat[[1]]),
                                          !!sym(longlat[[2]])))) |>
-      as_cubble(key = id, index = time, coords = longlat)
+      as_cubble(key = id, index = !!index, coords = longlat)
   }
 }
 

--- a/R/sf.R
+++ b/R/sf.R
@@ -14,7 +14,7 @@ make_spatial_sf <-  function(x, sfc = NULL, crs, silent = FALSE) {
 	stopifnot(is_cubble_spatial(x),
 			  is.null(sfc) || inherits(sfc, "sfc"),
 			  missing(crs) || inherits(crs, "crs"),
-			  all(c("long", "lat") %in% names(x)))
+			  all(c("long", "lat") %in% names(x)) || all(c("x", "y") %in% names(x)))
 	if (! requireNamespace("sf", quietly = TRUE))
 		stop("package sf required, please install it first")
 	if (is.null(sfc)) {

--- a/vignettes/cb2create.Rmd
+++ b/vignettes/cb2create.Rmd
@@ -79,7 +79,7 @@ as_cubble(raw, vars = "q",
 ```{r}
 tif <- system.file("tif/L7_ETMs.tif", package = "stars")
 x <- stars::read_stars(tif)
-as_cubble(x)
+as_cubble(x, index = band)
 ```
 
 When the `dimensions` object is too complex for the `cubble` package to handle, a warning message will be generated.


### PR DESCRIPTION
Hi @huizezhang-sherry, I was playing a bit with the `as_cubble()` function to coerce stars objects to cubble and noted a couple of things. 

1. To coerce from a vector data cube the `sfc` dimension had to be the first dimension in the data cube. This is because of an `if` check, so I think this could be safely replaced with a check over all dimensions and testing the condition as if any of the dimensions inherits `sfc`.

2. The raster data cube coercion assumes that time is the third dimension, but this is not always the case. In the example of the documentation, the band dimension is mistankenly taken as the time dimension. This creates the cubble correctly but trying to call `face_temporal()` for example, fails since it cannot find the time column in the data. I would think that letting the user define the time dimension would be cleaner and more straightforward. Maybe the examples need to be rethought since it does not make sense to add band as time, but it is theoretically possible to do so!

3. Also, I was testing the `make_spatial_sf()` function and noticed that it fails if the lat/long columns are x/y, so I added a line to include that case as well. 