### PR TITLE
delete invalid params in geom_glyph

### DIFF
--- a/R/glyph.R
+++ b/R/glyph.R
@@ -59,8 +59,7 @@
 #'     geom_glyph(y_scale = GGally::range01, polar = TRUE)
 #' print_p(p)
 geom_glyph <- function(mapping = NULL, data = NULL, stat = "identity",
-                       position = "identity", ..., x_major = NULL,
-                       x_minor = NULL, y_major = NULL, y_minor = NULL,
+                       position = "identity", ...,
                        x_scale = identity, y_scale = identity,
                        polar = FALSE, width = ggplot2::rel(2.1),
                        height = ggplot2::rel(1.8), global_rescale = TRUE,


### PR DESCRIPTION
I create this PR to complete GSoC2024 project [glyph-map-for-visualizing-spatio‐temporal-data](https://github.com/rstats-gsoc/gsoc2024/wiki/glyph-map-for-visualizing-spatio%E2%80%90temporal-data) hard test, which requests contributor to make a small change `to geom_glyph` in this repo.