### PR TITLE
Add error handling for rescale01 function

### DIFF
--- a/R/glyph.R
+++ b/R/glyph.R
@@ -51,7 +51,7 @@
 #'
 #' # apply a re-scaling on Y and use polar coordinate
 #' p <-
-#'   GGally::nasa |> 
+#'   GGally::nasa |>
 #'   ggplot(aes(x_major = long, x_minor = day,
 #'              y_major = lat, y_minor = ozone)) +
 #'     geom_glyph_box(fill=NA) +
@@ -215,6 +215,18 @@ rescale01 <- function(x, xlim=NULL) {
   } else {
     rng <- xlim
   }
+
+  ########### Adjustment
+  # Problem: In the case where elements of `x_minor` don't vary, it will lead to
+  # the divsion by zero in the scaling formula.
+  # Check if rng has a single value or both values are the same
+  if (length(rng) == 1 || rng[1] == rng[2]) {
+    # Adjust rng to create a minimal artificial range
+    rng <- c(rng[1] - 1, rng[2] + 1)  # Slightly adjust rng to avoid division of zero
+  }
+  ###############
+
+  # Proceed with scaling if rng is valid
   (x - rng[1]) / (rng[2] - rng[1])
 }
 
@@ -262,7 +274,7 @@ glyph_data_setup <- function(data, params){
   if (has_scale(params$x_scale)) {
     x_scale <- get_scale(params$x_scale)
     data <-
-      data |> 
+      data |>
       dplyr::mutate(
         x_minor = x_scale(.data$x_minor)
       )
@@ -271,7 +283,7 @@ glyph_data_setup <- function(data, params){
   if (has_scale(params$y_scale)) {
     y_scale <- get_scale(params$y_scale)
     data <-
-      data |> 
+      data |>
       dplyr::mutate(
         y_minor = y_scale(.data$y_minor)
       )
@@ -283,7 +295,7 @@ glyph_data_setup <- function(data, params){
     data[["x_minor"]] <- as.numeric(data[["x_minor"]])
   }
 
-  data <- data |> 
+  data <- data |>
     dplyr::mutate(
       polar = params$polar,
       width = ifelse(!is.rel(params$width), unclass(params$width),
@@ -299,14 +311,14 @@ glyph_data_setup <- function(data, params){
     theta <- 2 * pi * rescale01(data$x_minor)
     r <- rescale01(data$y_minor)
 
-    data <- data |> 
+    data <- data |>
       dplyr::mutate(x = .data$x_major + .data$width / 2 * r * sin(theta),
-                    y = .data$y_major + .data$height / 2 * r * cos(theta)) |> 
+                    y = .data$y_major + .data$height / 2 * r * cos(theta)) |>
       dplyr::arrange(.data$x_major, .data$x_minor)
 
   } else {
     if (isTRUE(params$global_rescale)) data <- data |>  dplyr::ungroup()
-    data <- data |> 
+    data <- data |>
       dplyr::mutate(
         x = .data$x_major + rescale11(.data$x_minor) * .data$width / 2,
         y = .data$y_major + rescale11(.data$y_minor) * .data$height / 2)
@@ -327,10 +339,10 @@ calc_ref_line <- function(data, params){
       y = .data$y_major + .data$height / 4 * cos(theta)
     )
   } else{
-    ref_line <- ref_line |> 
+    ref_line <- ref_line |>
       dplyr::mutate(group = .data$group,
                     x = .data$x_major + .data$width/ 2,
-                    y = .data$y_major) |> 
+                    y = .data$y_major) |>
       rbind(ref_line |>  dplyr::mutate(group = .data$group,
                                        x = .data$x_major - .data$width / 2,
                                        y = .data$y_major))
@@ -341,7 +353,7 @@ calc_ref_line <- function(data, params){
 
 
 calc_ref_box <- function(data, params){
-  ref_box <- data |> 
+  ref_box <- data |>
     dplyr::mutate(xmin = .data$x_major - .data$width / 2,
                    xmax = .data$x_major + .data$width / 2,
                    ymin = .data$y_major - .data$height / 2,

--- a/tests/testthat/_snaps/sf.md
+++ b/tests/testthat/_snaps/sf.md
@@ -14,3 +14,19 @@
       2 ASN00086077  145. -38.0  12.1 moora~  94870 <tibble>   (145.0964 -37.98)
       3 ASN00086282  145. -37.7 113.  melbo~  94866 <tibble> (144.8321 -37.6655)
 
+---
+
+    Code
+      make_spatial_sf(rename(climate_mel, x = long, y = lat))
+    Message
+      CRS missing: using OGC:CRS84 (WGS84) as default
+    Output
+      # cubble:   key: id [3], index: date, nested form, [sf]
+      # spatial:  [144.8321, -37.98, 145.0964, -37.6655], WGS 84
+      # temporal: date [date], prcp [dbl], tmax [dbl], tmin [dbl]
+        id              x     y  elev name   wmo_id ts                  geometry
+        <chr>       <dbl> <dbl> <dbl> <chr>   <dbl> <list>           <POINT [°]>
+      1 ASN00086038  145. -37.7  78.4 essen~  95866 <tibble> (144.9066 -37.7276)
+      2 ASN00086077  145. -38.0  12.1 moora~  94870 <tibble>   (145.0964 -37.98)
+      3 ASN00086282  145. -37.7 113.  melbo~  94866 <tibble> (144.8321 -37.6655)
+


### PR DESCRIPTION
This pull request addresses an issue in the rescale01 function where constant or non-varying input values (including a uniform xlim) led to a division by zero, causing errors in data scaling. I've introduced a safeguard mechanism that:

Checks for the scenario where the range (rng) derived from the input x or provided xlim is constant or non-varying.
I've also implemented a fallback strategy by slightly modifying rng to introduce a minimal range, allowing the scaling operation to proceed without division by zero errors.