### PR TITLE
Allow passing arguments to update_cubble()

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -46,9 +46,9 @@ update_cubble <- function(data, key, index, coords, ...){
 update_cubble.spatial_cubble_df <- function(data, key = NULL,
                                             index = NULL, coords = NULL, ...){
   is_cubble(data)
-  key <- key_vars(data)
-  index <- index_var(data)
-  coords <- coords(data)
+  key <- key %||% key_vars(data)
+  index <- index %||% index_var(data)
+  coords <- coords %||% coords(data)
 
   data |> new_spatial_cubble(key = key, index = index, coords = coords)
 


### PR DESCRIPTION
Hi Sherry,

I was looking for a function where I could update the key and index of a cubble and bumped into `update_cubble()`. 
However, internally the key, index, etc. are preset to the original values from the data object. Adding a simple check for NULL values would allow to pass the arguments and in fact update the cubble. This would be mainly helpful for me since `new_spatial_cubble()` is not exported. I hope this doesn't break anything, I did not test much yet. 